### PR TITLE
Fix variable name in getSubsysString()

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ function getSubsysString(subsys) {
     if (typeof subsys === 'number') {
         for (var k in subSys) {
             if (subSys.hasOwnProperty(k) && subSys[k] === subsys) {
-                cmdString = k;
+                subsysString = k;
                 break;
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unpi",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Unified Network Processor Interface for Texas Instruments Wireless SoCs.",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
I'm adding ZStack driver to mozilla IOT and found this issue